### PR TITLE
streamlined English translations

### DIFF
--- a/copy_this/modules/jxmods/jxnmaimport/views/admin/en/jxnmaimport_lang.php
+++ b/copy_this/modules/jxmods/jxnmaimport/views/admin/en/jxnmaimport_lang.php
@@ -9,7 +9,7 @@ $aLang = array(
     'JXNMAIMPORT_MPN'          => 'Herst.-Art.-Nr. (MPN)',
 
     'SHOP_MODULE_GROUP_JXNMAIMPORT_IMPORT'            => 'Import Settings',
-    'SHOP_MODULE_sJxNmaImportDelimeter'               => 'CSV Delimeter',
+    'SHOP_MODULE_sJxNmaImportDelimeter'               => 'CSV delimeter',
     'SHOP_MODULE_sJxNmaImportDelimeter_comma'         => ',',
     'SHOP_MODULE_sJxNmaImportDelimeter_semicolon'     => ';',
     'SHOP_MODULE_sJxNmaImportDelimeter_tabulator'     => 'Tab',


### PR DESCRIPTION
If possible from the space side, I'd suggest to not use "NA" as an abbreviation for "not available". It might be mixed up with the abbreviation for "North America".
